### PR TITLE
[Feat] Implement HUD in UIScene with phase logic

### DIFF
--- a/src/game/config/uiConfig.js
+++ b/src/game/config/uiConfig.js
@@ -60,11 +60,11 @@ export const UIConfig = {
         },
         phaseIcons: {
             x: 86.97 / 2,
-            y: 84.95 / 2
+            y: (84.95 + 6) / 2
         },
         territoryCards: {
             x: 408.97 - (86.97 / 2),
-            y: 84.95 / 2
+            y: (84.95 + 6) / 2
         }
     }
 }

--- a/src/game/config/uiConfig.js
+++ b/src/game/config/uiConfig.js
@@ -51,7 +51,7 @@ export const UIConfig = {
         },
         phaseBars: {
             x: 107,
-            y: 40,
+            y: 36,
             offsets: {
                 fortify: 0,
                 attack: 70,

--- a/src/game/config/uiConfig.js
+++ b/src/game/config/uiConfig.js
@@ -1,3 +1,4 @@
+import { toHex } from '../utils/toHex.js';
 import { COLORS } from './colors.js';
 import { GameConfig } from './gameConfig.js';
 
@@ -45,7 +46,7 @@ export const UIConfig = {
             textStyle: {
                 fontSize: '16px',
                 fontFamily: 'JetBrainsMono',
-                color: COLORS.primary,
+                color: toHex(COLORS.primary),
                 align: 'center'
             }
         },
@@ -65,6 +66,16 @@ export const UIConfig = {
         territoryCards: {
             x: 408.97 - (86.97 / 2),
             y: (84.95 + 6) / 2
+        },
+        territoryCardsCount: {
+            x: 408.97 - (86.97 / 2),
+            y: 84.95 / 2,
+            textStyle: {
+                fontSize: '22px',
+                fontFamily: 'JetBrainsMono',
+                color: toHex(COLORS.white),
+                align: 'center'
+            }
         }
     }
 }

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -26,15 +26,12 @@ export class UIScene extends Phaser.Scene {
 
         let currentPlayer = this.gameStateManager.getCurrentPlayer();
 
-        this.phaseText = this.add.text(10, 10, `Fase: `);
-
         this.confirmButton = null;
 
         this.hud.updateColor(currentPlayer.color);
 
         this.createTargetButton();        
         this.setupEvents();
-        this.updatePhaseText(this.gameStateManager.getCurrentPhase());
     }
 
     setupEvents() {
@@ -44,7 +41,6 @@ export class UIScene extends Phaser.Scene {
         this.hud.nextButton.on('pointerdown', () => {
             this.gameStateManager.emit('ui:endPhaseClicked');
         });
-        this.gameStateManager.on('game:phaseChanged', this.updatePhaseText, this);
         this.gameStateManager.on('game:error', (message) => {
             alert(message);
         }, this);
@@ -86,10 +82,6 @@ export class UIScene extends Phaser.Scene {
                 this.targetElipse.setTint(newPlayer.color);
             }
         }, this);
-    }
-
-    updatePhaseText(newPhase) {
-        this.phaseText.setText(`Fase: ${newPhase}`);
     }
 
     showTroopInput(territory, currentPlayer) {

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -25,15 +25,8 @@ export class UIScene extends Phaser.Scene {
         const leftX = padding;
 
         let currentPlayer = this.gameStateManager.getCurrentPlayer();
-        this.label = this.add.text(leftX, bottomY, 'Turno do Jogador #' + currentPlayer.name, {
-            font: '15px Arial',
-            fill: '#ffffff',
-            backgroundColor: `#${currentPlayer.color.toString(16).padStart(6, '0')}`,
-            padding: { x: 10, y: 10 },
-            align: 'center'
-        }).setOrigin(0, 1);
 
-        this.button = this.add.text(leftX, bottomY - this.label.height, 'Próximo turno', {
+        this.button = this.add.text(leftX, bottomY, 'Próximo turno', {
             font: '12px Arial',
             fill: '#ffffff',
             backgroundColor: '#007bff',
@@ -65,7 +58,6 @@ export class UIScene extends Phaser.Scene {
         this.hud.nextButton.on('pointerdown', () => {
             this.gameStateManager.emit('ui:endPhaseClicked');
         });
-        this.gameStateManager.on('game:nextTurn', this.updateTurnLabel, this);
         this.gameStateManager.on('game:phaseChanged', this.updateButtonText, this);
         this.gameStateManager.on('game:phaseChanged', this.updatePhaseText, this);
         this.gameStateManager.on('game:error', (message) => {
@@ -90,7 +82,7 @@ export class UIScene extends Phaser.Scene {
         }, this);
 
         this.gameStateManager.on('game:nextTurn', (player) => {
-            this.hud.updateColor(player.color); // <--- Chamada dinâmica
+            this.hud.updateColor(player.color); 
         }, this);
         this.gameStateManager.on('game:destinationSelected', (destinationTerritory, originTerritory) => {
             this.showConfirmButton("Confirm Strategy", () => {
@@ -109,13 +101,6 @@ export class UIScene extends Phaser.Scene {
                 this.targetElipse.setTint(newPlayer.color);
             }
         }, this);
-    }
-
-    updateTurnLabel(newPlayer) {
-        this.label.setText("Turno do jogador # " + newPlayer.name);
-        this.label.setStyle({
-            backgroundColor: `#${newPlayer.color.toString(16).padStart(6, '0')}`
-        });
     }
 
     updateButtonText(newPhase) {

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -247,7 +247,7 @@ export class UIScene extends Phaser.Scene {
 
     showConfirmButton(text, callback) {
         const centerX = this.cameras.main.centerX;
-        const bottomY = this.cameras.main.height - 20;
+        const bottomY = 20;
 
         this.confirmButton = this.add.text(centerX, bottomY, text, {
             font: '16px Arial',
@@ -256,7 +256,7 @@ export class UIScene extends Phaser.Scene {
             padding: { x: 10, y: 10 },
             align: 'center'
         })
-            .setOrigin(0, 1)
+            .setOrigin(0.5, 0)
             .setInteractive();
 
         this.confirmButton.on('pointerdown', callback);

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -20,10 +20,6 @@ export class UIScene extends Phaser.Scene {
         const initialPhase = this.gameStateManager.getCurrentPhase();
         this.hud.updatePhase(initialPhase);
 
-        const padding = 20;
-        const bottomY = this.cameras.main.height - padding;
-        const leftX = padding;
-
         let currentPlayer = this.gameStateManager.getCurrentPlayer();
 
         this.confirmButton = null;

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -26,28 +26,14 @@ export class UIScene extends Phaser.Scene {
 
         let currentPlayer = this.gameStateManager.getCurrentPlayer();
 
-        this.button = this.add.text(leftX, bottomY, 'Próximo turno', {
-            font: '12px Arial',
-            fill: '#ffffff',
-            backgroundColor: '#007bff',
-            padding: { x: 8, y: 8 },
-            align: 'center'
-        })
-            .setOrigin(0, 1)
-            .setInteractive();
-
         this.phaseText = this.add.text(10, 10, `Fase: `);
 
-        this.button.on('pointerdown', () => {
-            this.gameStateManager.emit('ui:endPhaseClicked');
-        });
         this.confirmButton = null;
 
         this.hud.updateColor(currentPlayer.color);
 
         this.createTargetButton();        
         this.setupEvents();
-        this.updateButtonText(this.gameStateManager.getCurrentPhase());
         this.updatePhaseText(this.gameStateManager.getCurrentPhase());
     }
 
@@ -58,7 +44,6 @@ export class UIScene extends Phaser.Scene {
         this.hud.nextButton.on('pointerdown', () => {
             this.gameStateManager.emit('ui:endPhaseClicked');
         });
-        this.gameStateManager.on('game:phaseChanged', this.updateButtonText, this);
         this.gameStateManager.on('game:phaseChanged', this.updatePhaseText, this);
         this.gameStateManager.on('game:error', (message) => {
             alert(message);
@@ -101,14 +86,6 @@ export class UIScene extends Phaser.Scene {
                 this.targetElipse.setTint(newPlayer.color);
             }
         }, this);
-    }
-
-    updateButtonText(newPhase) {
-        if (newPhase === TURN_PHASES.FIRST_REINFORCEMENT || newPhase === TURN_PHASES.END) {
-            this.button.setText('Finalizar turno');
-        } else {
-            this.button.setText('Próxima fase');
-        }
     }
 
     updatePhaseText(newPhase) {

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -1,5 +1,6 @@
 import { Scene } from 'phaser';
 import { TURN_PHASES } from '../managers/TurnManager';
+import { GameHUD } from '../ui/GameHUD';
 
 export class UIScene extends Phaser.Scene {
     constructor() {
@@ -14,6 +15,11 @@ export class UIScene extends Phaser.Scene {
     }
 
     create() {
+        this.hud = new GameHUD(this);
+
+        const initialPhase = this.gameStateManager.getCurrentPhase();
+        this.hud.updatePhase(initialPhase);
+
         const padding = 20;
         const bottomY = this.cameras.main.height - padding;
         const leftX = padding;
@@ -51,6 +57,12 @@ export class UIScene extends Phaser.Scene {
     }
 
     setupEvents() {
+        this.gameStateManager.on('game:phaseChanged', (newPhase) => {
+            this.hud.updatePhase(newPhase);
+        }, this);
+        this.hud.nextButton.on('pointerdown', () => {
+            this.gameStateManager.emit('ui:endPhaseClicked');
+        });
         this.gameStateManager.on('game:nextTurn', this.updateTurnLabel, this);
         this.gameStateManager.on('game:phaseChanged', this.updateButtonText, this);
         this.gameStateManager.on('game:phaseChanged', this.updatePhaseText, this);

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -50,6 +50,8 @@ export class UIScene extends Phaser.Scene {
         });
         this.confirmButton = null;
 
+        this.hud.updateColor(currentPlayer.color);
+
         this.createTargetButton();        
         this.setupEvents();
         this.updateButtonText(this.gameStateManager.getCurrentPhase());
@@ -87,7 +89,9 @@ export class UIScene extends Phaser.Scene {
             this.showAttackInput(attackerTerritory, defenderTerritory);
         }, this);
 
-
+        this.gameStateManager.on('game:nextTurn', (player) => {
+            this.hud.updateColor(player.color); // <--- Chamada dinâmica
+        }, this);
         this.gameStateManager.on('game:destinationSelected', (destinationTerritory, originTerritory) => {
             this.showConfirmButton("Confirm Strategy", () => {
                 this.gameStateManager.emit('game:strategyConfirmed', destinationTerritory, originTerritory, this);

--- a/src/game/scenes/UIScene.js
+++ b/src/game/scenes/UIScene.js
@@ -18,15 +18,17 @@ export class UIScene extends Phaser.Scene {
         this.hud = new GameHUD(this);
 
         const initialPhase = this.gameStateManager.getCurrentPhase();
-        this.hud.updatePhase(initialPhase);
-
         let currentPlayer = this.gameStateManager.getCurrentPlayer();
 
+        this.hud.updatePhase(initialPhase);
+
+        if(currentPlayer) {
+            this.hud.updateColor(currentPlayer.color);
+        }
+
         this.confirmButton = null;
+        this.createTargetButton();
 
-        this.hud.updateColor(currentPlayer.color);
-
-        this.createTargetButton();        
         this.setupEvents();
     }
 

--- a/src/game/ui/GameHUD.js
+++ b/src/game/ui/GameHUD.js
@@ -24,6 +24,12 @@ export class GameHUD extends GameObjects.Container {
             config.centerBar.y, 
             'center-bar'
         ).setOrigin(0, 0);
+
+        this.centerBarStroke = scene.add.image(
+            config.centerBar.x, 
+            config.centerBar.y, 
+            'center-bar-stroke'
+        ).setOrigin(0, 0);
         
         this.phaseLabelBackground = scene.add.image(
             config.phaseLabel.x, 
@@ -72,6 +78,7 @@ export class GameHUD extends GameObjects.Container {
 
         this.add([
             this.centerBar, 
+            this.centerBarStroke,
             this.leftPanel, 
             this.rightPanel, 
             this.phaseIcon,

--- a/src/game/ui/GameHUD.js
+++ b/src/game/ui/GameHUD.js
@@ -82,6 +82,13 @@ export class GameHUD extends GameObjects.Container {
             'territory-cards'
         ).setOrigin(0.5);
 
+        this.territoryCardsCount = scene.add.text(
+            config.territoryCardsCount.x,
+            config.territoryCardsCount.y,
+            '0',
+            config.territoryCardsCount.textStyle
+        ).setOrigin(0.5, 0.5);
+
         this.add([
             this.centerBar, 
             this.centerBarStroke,
@@ -89,6 +96,7 @@ export class GameHUD extends GameObjects.Container {
             this.rightPanel, 
             this.phaseIcon,
             this.territoryCards,
+            this.territoryCardsCount,
             this.phaseLabelBackground, 
             this.phaseLabel,
             ...Object.values(this.phaseBars),
@@ -148,5 +156,9 @@ export class GameHUD extends GameObjects.Container {
         this.rightPanel.setTint(color);
         this.centerBarStroke.setTint(color);
         this.nextButton.setTint(color);
+    }
+
+    updateTerritoryCardsCount(count) {
+        this.territoryCardsCount.setText(count.toString())
     }
 }

--- a/src/game/ui/GameHUD.js
+++ b/src/game/ui/GameHUD.js
@@ -76,12 +76,19 @@ export class GameHUD extends GameObjects.Container {
             config.nextTurnButton.textStyle
         ).setOrigin(0.5, 0.5);
 
+        this.territoryCards = scene.add.image(
+            config.territoryCards.x,
+            config.territoryCards.y,
+            'territory-cards'
+        ).setOrigin(0.5);
+
         this.add([
             this.centerBar, 
             this.centerBarStroke,
             this.leftPanel, 
             this.rightPanel, 
             this.phaseIcon,
+            this.territoryCards,
             this.phaseLabelBackground, 
             this.phaseLabel,
             ...Object.values(this.phaseBars),

--- a/src/game/ui/GameHUD.js
+++ b/src/game/ui/GameHUD.js
@@ -108,12 +108,15 @@ export class GameHUD extends GameObjects.Container {
     }
 
     updatePhase(currentPhase) {
+        const fortifyConfig = {
+            text: 'FORTIFICAÇÃO',
+            icon: 'icon-fortify-phase',
+            activeBar: 'fortify'
+        };
+
         const phaseConfig = {
-            [TURN_PHASES.REINFORCEMENT]: { 
-                text: 'FORTIFICAÇÃO',
-                icon: 'icon-fortify-phase',
-                activeBar: 'fortify'
-            },
+            [TURN_PHASES.FIRST_REINFORCEMENT]: fortifyConfig,
+            [TURN_PHASES.REINFORCEMENT]: fortifyConfig,
             [TURN_PHASES.ATTACK]: { 
                 text: 'ATAQUE',
                 icon: 'icon-attack-phase',
@@ -143,7 +146,7 @@ export class GameHUD extends GameObjects.Container {
                 this.phaseBars[key].setTexture(isActive ? 'phase-bar-active' : 'phase-bar-inactive');
             });
 
-            if (currentPhase === TURN_PHASES.STRATEGIC) {
+            if (currentPhase === TURN_PHASES.STRATEGIC || currentPhase === TURN_PHASES.FIRST_REINFORCEMENT) {
                 this.nextButtonText.setText('ENCERRAR');
             } else {
                 this.nextButtonText.setText('PRÓXIMO');

--- a/src/game/ui/GameHUD.js
+++ b/src/game/ui/GameHUD.js
@@ -38,6 +38,12 @@ export class GameHUD extends GameObjects.Container {
             config.phaseLabel.textStyle
         ).setOrigin(0.5, 0.5);
 
+        this.phaseIcon = scene.add.image(
+            config.phaseIcons.x,
+            config.phaseIcons.y,
+            'icon-fortify-phase' 
+        ).setOrigin(0.5, 0.5);
+
         this.phaseBars = {};
         const barConfig = config.phaseBars;
         
@@ -68,6 +74,7 @@ export class GameHUD extends GameObjects.Container {
             this.centerBar, 
             this.leftPanel, 
             this.rightPanel, 
+            this.phaseIcon,
             this.phaseLabelBackground, 
             this.phaseLabel,
             ...Object.values(this.phaseBars),
@@ -79,21 +86,46 @@ export class GameHUD extends GameObjects.Container {
     }
 
     updatePhase(currentPhase) {
-        const texts = {
-            [TURN_PHASES.REINFORCEMENT]: 'FORTIFICAÇÃO',
-            [TURN_PHASES.ATTACK]: 'ATAQUE',
-            [TURN_PHASES.STRATEGIC]: 'MOVIMENTAÇÃO',
-            [TURN_PHASES.END]: 'FIM DE TURNO'
+        const phaseConfig = {
+            [TURN_PHASES.REINFORCEMENT]: { 
+                text: 'FORTIFICAÇÃO',
+                icon: 'icon-fortify-phase',
+                activeBar: 'fortify'
+            },
+            [TURN_PHASES.ATTACK]: { 
+                text: 'ATAQUE',
+                icon: 'icon-attack-phase',
+                activeBar: 'attack'
+            },
+            [TURN_PHASES.STRATEGIC]: { 
+                text: 'MOVIMENTAÇÃO',
+                icon: 'icon-relocation-phase',
+                activeBar: 'relocate'
+            },
+            [TURN_PHASES.END]: { 
+                text: 'FIM DE TURNO',
+                icon: 'icon-fortify-phase',
+                activeBar: null
+            }
         };
-        this.phaseLabel.setText(texts[currentPhase]);
 
-        Object.keys(this.phaseBars).forEach(key => {
-            let isActive = false;
-            if (key === 'fortify' && currentPhase === TURN_PHASES.REINFORCEMENT) isActive = true;
-            if (key === 'attack' && currentPhase === TURN_PHASES.ATTACK) isActive = true;
-            if (key === 'relocate' && currentPhase === TURN_PHASES.STRATEGIC) isActive = true;
+        const config = phaseConfig[currentPhase];
 
-            this.phaseBars[key].setTexture(isActive ? 'phase-bar-active' : 'phase-bar-inactive');
-        });
+        if (config) {
+            this.phaseLabel.setText(config.text);
+            
+            this.phaseIcon.setTexture(config.icon);
+
+            Object.keys(this.phaseBars).forEach(key => {
+                const isActive = (key === config.activeBar);
+                this.phaseBars[key].setTexture(isActive ? 'phase-bar-active' : 'phase-bar-inactive');
+            });
+
+            if (currentPhase === TURN_PHASES.STRATEGIC) {
+                this.nextButtonText.setText('ENCERRAR');
+            } else {
+                this.nextButtonText.setText('PRÓXIMO');
+            }
+        }
     }
 }

--- a/src/game/ui/GameHUD.js
+++ b/src/game/ui/GameHUD.js
@@ -135,4 +135,11 @@ export class GameHUD extends GameObjects.Container {
             }
         }
     }
+
+    updateColor(color) {
+        this.leftPanel.setTint(color);
+        this.rightPanel.setTint(color);
+        this.centerBarStroke.setTint(color);
+        this.nextButton.setTint(color);
+    }
 }

--- a/src/game/utils/toHex.js
+++ b/src/game/utils/toHex.js
@@ -1,0 +1,1 @@
+export const toHex = (color) => '#' + color.toString(16).padStart(6, '0');


### PR DESCRIPTION
Substituição da interface antiga (textos soltos) pelo componente visual definitivo GameHUD. O novo HUD centraliza as informações do jogo no rodapé da tela, incluindo o rastreador de fases, quantidade de cartas de território, e um botão para pular de fase.

**O que foi alterado:**
Refatoração da UIScene.js;

Removidos todos os textos de debug antigos;

Instanciação do GameHUD no método create();

Conexão de eventos do GameStateManager aos métodos do HUD:
- `game:phaseChanged` > Atualiza ícone, texto e barras.
- `game:nextTurn` > Atualiza a cor do HUD para a cor do novo jogador.

Ajuste na importação de cores (colors.js) e conversão para hexadecimal string onde necessário;

**Coloração Dinâmica** > Implementado método updateColor(color) que aplica setTint nos painéis, stroke central e botão de acordo com a cor do jogador.

<img width="509" height="143" alt="image" src="https://github.com/user-attachments/assets/189bc5d9-4d6b-4219-9540-b730f20ac554" />
