### PR TITLE
[Feat] Implement automatic save after end of turn

### DIFF
--- a/src/game/managers/GameController.js
+++ b/src/game/managers/GameController.js
@@ -1,5 +1,7 @@
 import { TURN_PHASES } from "./TurnManager";
 import { executeCombat } from "../utils/diceRoller";
+import { storePlayers } from "../utils/store";
+import { storeTerritories } from "../utils/store";
 
 export default class GameController {
     constructor(gsm) {
@@ -305,6 +307,8 @@ export default class GameController {
         const newPlayer = turnManager.getCurrentPlayer();
         this.gsm.playerManager.calculateReinforcements(newPlayer);
         this.movementController.reset();
+        storeTerritories(this.gsm.mapManager.territories);
+        storePlayers(this.gsm.playerManager.getPlayers(), this.gsm.getCurrentPlayer());
         this.gsm.emit("game:nextTurn", newPlayer);
     }
 

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -84,6 +84,7 @@ export class MainMenu extends Scene
 
     changeScene ()
     {
+        localStorage.clear();
         this.scene.start('PlayerSelection');
     }
 }

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -2,6 +2,7 @@ import { EventBus } from '../EventBus';
 import { Scene } from 'phaser';
 import { GameConfig } from '../config/gameConfig'
 import { COLORS } from '../config/colors';
+import { deleteOngoingGame } from '../utils/store';
 
 export class MainMenu extends Scene
 {
@@ -84,7 +85,7 @@ export class MainMenu extends Scene
 
     changeScene ()
     {
-        localStorage.clear();
+        deleteOngoingGame();
         this.scene.start('PlayerSelection');
     }
 }

--- a/src/game/utils/diceRoller.js
+++ b/src/game/utils/diceRoller.js
@@ -1,5 +1,3 @@
-import Territory from "../gameObjects/Territory";
-
 export function executeCombat(attackingTroops, defenseTerritory) {
     const defense = Math.min(3,defenseTerritory.getTroopCount());
     // gera valores em ordem decrescente

--- a/src/game/utils/store.js
+++ b/src/game/utils/store.js
@@ -1,0 +1,8 @@
+export function storePlayers(players, currentPlayer){
+        localStorage.setItem('players', JSON.stringify(players));
+        localStorage.setItem('currentPlayer', JSON.stringify(currentPlayer));
+    }
+
+export function storeTerritories(territories){
+        localStorage.setItem('territories', JSON.stringify(territories));
+    }

--- a/src/game/utils/store.js
+++ b/src/game/utils/store.js
@@ -6,3 +6,9 @@ export function storePlayers(players, currentPlayer){
 export function storeTerritories(territories){
         localStorage.setItem('territories', JSON.stringify(territories));
     }
+
+export function deleteOngoingGame(){
+    localStorage.removeItem('players');
+    localStorage.removeItem('currentPlayer');
+    localStorage.removeItem('territories');
+}


### PR DESCRIPTION
added file 'Store' to deal with saving/loading gamestates
created call to save method in between turns
Now, upon entering player selection, any data from previous ongoing game is deleted
removed unused import in diceRoller
